### PR TITLE
fix to support nim v1.2

### DIFF
--- a/nimpb/json.nim
+++ b/nimpb/json.nim
@@ -16,7 +16,7 @@ proc `%`*(u: uint32): JsonNode =
     newJFloat(float(u))
 
 proc `%`*(b: seq[byte]): JsonNode =
-    result = newJString(base64.encode(cast[string](b), newLine=""))
+    result = newJString(base64.encode(cast[string](b)))
 
 proc toJson*(value: float): JsonNode =
     case classify(value)


### PR DESCRIPTION
This change seems to be necessary to build on v1.2. We can build both v1.0 and v1.2.